### PR TITLE
queries can come from fd addresses, not just fe80

### DIFF
--- a/respondd
+++ b/respondd
@@ -193,7 +193,7 @@ socket.on('error', (err) => {
 })
 
 socket.on('message', (msg, rinfo) => {
-  if (!rinfo.address.startsWith("fe80:")) return
+  if (!rinfo.address.startsWith("f")) return
   msg = msg.toString()
   console.log("message from: "+rinfo.address+": "+msg)
   if (msg.startsWith("GET ")) {


### PR DESCRIPTION
With the multicast address changed to `ff05::2:1001`, we are now seeing the respondd queries come from `fd4e:f2d7:88d2:ffff::250`. So the check needs to be weakened to make gateways appear again in hopglass.